### PR TITLE
Added support for SASL_SSL/SCRAM authentication

### DIFF
--- a/src/main/java/io/aiven/klaw/clusterapi/utils/ClusterApiUtils.java
+++ b/src/main/java/io/aiven/klaw/clusterapi/utils/ClusterApiUtils.java
@@ -90,39 +90,57 @@ public class ClusterApiUtils {
     try {
       switch (protocol) {
         case "PLAINTEXT":
-          if (!adminClientsMap.containsKey(adminClientKey))
+          if (!adminClientsMap.containsKey(adminClientKey)) {
             adminClient = AdminClient.create(getPlainProperties(envHost));
-          else {
+          } else {
             adminClient = adminClientsMap.get(adminClientKey);
           }
           break;
 
         case "SSL":
-          if (!adminClientsMap.containsKey(adminClientKey))
+          if (!adminClientsMap.containsKey(adminClientKey)) {
             adminClient = AdminClient.create(getSslProperties(envHost, clusterNameTenantId));
-          else adminClient = adminClientsMap.get(adminClientKey);
+          } else {
+            adminClient = adminClientsMap.get(adminClientKey);
+          }
           break;
 
         case "SASL_PLAIN":
-          if (!adminClientsMap.containsKey(adminClientKey))
+          if (!adminClientsMap.containsKey(adminClientKey)) {
             adminClient = AdminClient.create(getSaslPlainProperties(envHost, clusterNameTenantId));
-          else adminClient = adminClientsMap.get(adminClientKey);
+          } else {
+            adminClient = adminClientsMap.get(adminClientKey);
+          }
           break;
 
         case "SASL_SSL-PLAINMECHANISM":
-          if (!adminClientsMap.containsKey(adminClientKey))
+          if (!adminClientsMap.containsKey(adminClientKey)) {
             adminClient =
                 AdminClient.create(
                     getSaslSsl_PlainMechanismProperties(envHost, clusterNameTenantId));
-          else adminClient = adminClientsMap.get(adminClientKey);
+          } else {
+            adminClient = adminClientsMap.get(adminClientKey);
+          }
+          break;
+
+        case "SASL_SSL-SCRAMMECHANISM":
+          if (!adminClientsMap.containsKey(adminClientKey)) {
+            adminClient =
+                AdminClient.create(
+                    getSaslSsl_ScramMechanismProperties(envHost, clusterNameTenantId));
+          } else {
+            adminClient = adminClientsMap.get(adminClientKey);
+          }
           break;
 
         case "SASL_SSL-GSSAPIMECHANISM":
-          if (!adminClientsMap.containsKey(adminClientKey))
+          if (!adminClientsMap.containsKey(adminClientKey)) {
             adminClient =
                 AdminClient.create(
                     getSaslSsl_GSSAPIMechanismProperties(envHost, clusterNameTenantId));
-          else adminClient = adminClientsMap.get(adminClientKey);
+          } else {
+            adminClient = adminClientsMap.get(adminClientKey);
+          }
           break;
       }
     } catch (Exception exception) {
@@ -138,8 +156,9 @@ public class ClusterApiUtils {
 
     try {
       adminClient.listTopics().names().get();
-      if (!adminClientsMap.containsKey(adminClientKey))
+      if (!adminClientsMap.containsKey(adminClientKey)) {
         adminClientsMap.put(adminClientKey, adminClient);
+      }
       return adminClient;
     } catch (Exception e) {
       adminClientsMap.remove(adminClientKey);
@@ -217,6 +236,31 @@ public class ClusterApiUtils {
       }
     } catch (Exception exception) {
       log.error("Error : Cannot set SASL SSL PLAIN Config properties.");
+    }
+
+    return props;
+  }
+
+  public Properties getSaslSsl_ScramMechanismProperties(String environment, String clusterName) {
+    Properties props = getSslConfig(clusterName);
+
+    try {
+      props.put("bootstrap.servers", environment);
+      props.put(CommonClientConfigs.SECURITY_PROTOCOL_CONFIG, "SASL_SSL");
+      props.put(AdminClientConfig.CLIENT_ID_CONFIG, "klawclientsaslsslscram");
+      setOtherConfig(props);
+
+      if (!Strings.isNullOrEmpty(env.getProperty("kafkasasl.saslmechanism.scram"))) {
+        props.put(SaslConfigs.SASL_MECHANISM, env.getProperty("kafkasasl.saslmechanism.scram"));
+      }
+      if (!Strings.isNullOrEmpty(
+          env.getProperty(clusterName.toLowerCase() + ".kafkasasl.jaasconfig.scram"))) {
+        props.put(
+            SaslConfigs.SASL_JAAS_CONFIG,
+            env.getProperty(clusterName.toLowerCase() + ".kafkasasl.jaasconfig.scram"));
+      }
+    } catch (Exception exception) {
+      log.error("Error : Cannot set SASL SSL SCRAM Config properties.");
     }
 
     return props;

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -31,11 +31,13 @@ klawssl.kafkassl.truststore.type=JKS
 
 # SASL properties to connect to Kafka clusters
 #acc_cluster.kafkasasl.jaasconfig.plain=org.apache.kafka.common.security.plain.PlainLoginModule required username='kwuser' password='kwuser-secret';
+#acc_cluster.kafkasasl.jaasconfig.scram=org.apache.kafka.common.security.scram.ScramLoginModule required username='kwuser' password='kwuser-secret';
 #acc_cluster.kafkasasl.saslmechanism.gssapi.servicename=kafka
 #acc_cluster.kafkasasl.jaasconfig.gssapi=com.sun.security.auth.module.Krb5LoginModule required useKeyTab=true storeKey=true keyTab="/location/kafka_client.keytab" principal="kafkaclient1@EXAMPLE.COM";
 
 kafkasasl.saslmechanism.plain=PLAIN
 kafkasasl.saslmechanism.gssapi=GSSAPI
+kafkasasl.saslmechanism.scram=SCRAM-SHA-256
 
 
 # User/pwds for accessing Cluster api (pwd:amcryptic)


### PR DESCRIPTION
Introducing option to use SASL_SSL with SCRAM instead of simple username/password authentication. I would have liked to refactor this code further to avoid the copy/paste duplication - might come back later to do this once unit test coverage is improved for greater confidence.  