### PR TITLE
Minor refactorings

### DIFF
--- a/src/main/java/io/aiven/klaw/clusterapi/config/SslContextConfig.java
+++ b/src/main/java/io/aiven/klaw/clusterapi/config/SslContextConfig.java
@@ -44,7 +44,7 @@ public class SslContextConfig {
   public void setKwSSLContext() throws Exception {
     if (keyStore != null && !keyStore.equals("null")) {
       TrustStrategy acceptingTrustStrategy = (X509Certificate[] chain, String authType) -> true;
-      javax.net.ssl.SSLContext sslContext = null;
+      javax.net.ssl.SSLContext sslContext;
       try {
         sslContext =
             org.apache.http.ssl.SSLContexts.custom()

--- a/src/main/java/io/aiven/klaw/clusterapi/config/SslContextConfig.java
+++ b/src/main/java/io/aiven/klaw/clusterapi/config/SslContextConfig.java
@@ -1,9 +1,9 @@
 package io.aiven.klaw.clusterapi.config;
 
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.file.Files;
 import java.security.*;
 import java.security.cert.CertificateException;
 import java.security.cert.X509Certificate;
@@ -76,7 +76,7 @@ public class SslContextConfig {
     File key = ResourceUtils.getFile(storeLoc);
 
     final KeyStore store = KeyStore.getInstance(keyStoreType);
-    try (InputStream inputStream = new FileInputStream(key)) {
+    try (InputStream inputStream = Files.newInputStream(key.toPath())) {
       store.load(inputStream, secret.toCharArray());
     }
     return store;

--- a/src/main/java/io/aiven/klaw/clusterapi/controller/KafkaConnectController.java
+++ b/src/main/java/io/aiven/klaw/clusterapi/controller/KafkaConnectController.java
@@ -34,7 +34,7 @@ public class KafkaConnectController {
       value = "/getConnectorDetails/{connectorName}/{kafkaConnectHost}/{protocol}",
       method = RequestMethod.GET,
       produces = {MediaType.APPLICATION_JSON_VALUE})
-  public ResponseEntity<LinkedHashMap<String, Object>> getConnectorDetails(
+  public ResponseEntity<Map<String, Object>> getConnectorDetails(
       @PathVariable String connectorName,
       @PathVariable String kafkaConnectHost,
       @Valid @PathVariable KafkaSupportedProtocol protocol) {

--- a/src/main/java/io/aiven/klaw/clusterapi/services/ApacheKafkaTopicService.java
+++ b/src/main/java/io/aiven/klaw/clusterapi/services/ApacheKafkaTopicService.java
@@ -110,12 +110,10 @@ public class ApacheKafkaTopicService {
           .get(clusterTopicRequest.getTopicName())
           .get(TIME_OUT_SECS_FOR_TOPICS, TimeUnit.SECONDS);
     } catch (KafkaException e) {
-      String errorMessage = "Invalid properties: ";
-      log.error(errorMessage, e);
+      log.error("Invalid properties:", e);
       throw e;
     } catch (NumberFormatException e) {
-      String errorMessage = "Invalid replica assignment string";
-      log.error(errorMessage, e);
+      log.error("Invalid replica assignment string", e);
       throw e;
     } catch (ExecutionException | InterruptedException e) {
       String errorMessage;
@@ -197,8 +195,7 @@ public class ApacheKafkaTopicService {
           .get(TIME_OUT_SECS_FOR_TOPICS, TimeUnit.SECONDS);
       return ApiResponse.builder().result(ApiResultStatus.SUCCESS.value).build();
     } catch (KafkaException e) {
-      String errorMessage = "Invalid properties: ";
-      log.error(errorMessage, e);
+      log.error("Invalid properties:", e);
       throw e;
     } catch (ExecutionException | InterruptedException e) {
       String errorMessage;

--- a/src/main/java/io/aiven/klaw/clusterapi/services/KafkaConnectService.java
+++ b/src/main/java/io/aiven/klaw/clusterapi/services/KafkaConnectService.java
@@ -40,7 +40,7 @@ public class KafkaConnectService {
     try {
       reqDetails.getRight().delete(reqDetails.getLeft(), String.class);
     } catch (RestClientException e) {
-      log.error("Error in deleting connector " + e.toString());
+      log.error("Error in deleting connector", e);
       result.put("result", ApiResultStatus.ERROR.value);
       result.put("errorText", e.toString().replaceAll("\"", ""));
       return result;
@@ -71,7 +71,7 @@ public class KafkaConnectService {
     try {
       reqDetails.getRight().put(reqDetails.getLeft(), request, String.class);
     } catch (RestClientException e) {
-      log.error("Error in updating connector " + e.toString());
+      log.error("Error in updating connector", e);
       result.put("result", ApiResultStatus.ERROR.value);
       result.put("errorText", e.toString().replaceAll("\"", ""));
       return result;
@@ -100,7 +100,7 @@ public class KafkaConnectService {
       responseNew =
           reqDetails.getRight().postForEntity(reqDetails.getLeft(), request, String.class);
     } catch (RestClientException e) {
-      log.error("Error in registering new connector " + e.toString());
+      log.error("Error in registering new connector", e);
       throw new Exception(e.toString());
     }
     if (responseNew.getStatusCodeValue() == 201) {

--- a/src/main/java/io/aiven/klaw/clusterapi/services/KafkaConnectService.java
+++ b/src/main/java/io/aiven/klaw/clusterapi/services/KafkaConnectService.java
@@ -10,6 +10,7 @@ import io.aiven.klaw.clusterapi.utils.ClusterApiUtils;
 import java.util.*;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.tuple.Pair;
+import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.*;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestClientException;
@@ -18,6 +19,11 @@ import org.springframework.web.client.RestTemplate;
 @Service
 @Slf4j
 public class KafkaConnectService {
+
+  private static final ParameterizedTypeReference<List<String>> GET_CONNECTORS_TYPEREF =
+      new ParameterizedTypeReference<>() {};
+  private static final ParameterizedTypeReference<Map<String, Object>>
+      GET_CONNECTOR_DETAILS_TYPEREF = new ParameterizedTypeReference<>() {};
 
   final ClusterApiUtils clusterApiUtils;
 
@@ -122,18 +128,20 @@ public class KafkaConnectService {
           clusterApiUtils.getRequestDetails(suffixUrl, protocol, KafkaClustersType.KAFKA_CONNECT);
 
       Map<String, String> params = new HashMap<>();
-      ResponseEntity<List> responseList =
-          reqDetails.getRight().getForEntity(reqDetails.getLeft(), List.class, params);
+      ResponseEntity<List<String>> responseList =
+          reqDetails
+              .getRight()
+              .exchange(reqDetails.getLeft(), HttpMethod.GET, null, GET_CONNECTORS_TYPEREF, params);
 
       log.info("connectors list " + responseList);
       return responseList.getBody();
     } catch (Exception e) {
       log.error("Error in getting connectors " + e.getMessage());
-      return new ArrayList<>();
+      return Collections.emptyList();
     }
   }
 
-  public LinkedHashMap<String, Object> getConnectorDetails(
+  public Map<String, Object> getConnectorDetails(
       String connector, String environmentVal, KafkaSupportedProtocol protocol) {
     try {
       log.info("Into getConnectorDetails {} {}", environmentVal, protocol);
@@ -147,14 +155,21 @@ public class KafkaConnectService {
 
       Map<String, String> params = new HashMap<>();
 
-      ResponseEntity<LinkedHashMap> responseList =
-          reqDetails.getRight().getForEntity(reqDetails.getLeft(), LinkedHashMap.class, params);
+      ResponseEntity<Map<String, Object>> responseList =
+          reqDetails
+              .getRight()
+              .exchange(
+                  reqDetails.getLeft(),
+                  HttpMethod.GET,
+                  null,
+                  GET_CONNECTOR_DETAILS_TYPEREF,
+                  params);
       log.info("connectors list " + responseList);
 
       return responseList.getBody();
     } catch (Exception e) {
       log.error("Error in getting connector detail " + e.getMessage());
-      return new LinkedHashMap<>();
+      return Collections.emptyMap();
     }
   }
 

--- a/src/main/java/io/aiven/klaw/clusterapi/services/MonitoringService.java
+++ b/src/main/java/io/aiven/klaw/clusterapi/services/MonitoringService.java
@@ -75,10 +75,10 @@ public class MonitoringService {
         long latestOffset = listOffsetsLatestResult.partitionResult(topicPartition).get().offset();
         long lag = latestOffset - earliestOffset;
 
-        offsetDetails.put("topicPartitionId", topicPartition.partition() + "");
-        offsetDetails.put("currentOffset", earliestOffset + "");
-        offsetDetails.put("endOffset", latestOffset + "");
-        offsetDetails.put("lag", lag + "");
+        offsetDetails.put("topicPartitionId", Long.toString(topicPartition.partition()));
+        offsetDetails.put("currentOffset", Long.toString(earliestOffset));
+        offsetDetails.put("endOffset", Long.toString(latestOffset));
+        offsetDetails.put("lag", Long.toString(lag));
         consumerGroupOffsetList.add(offsetDetails);
       }
       return consumerGroupOffsetList;

--- a/src/main/java/io/aiven/klaw/clusterapi/services/MonitoringService.java
+++ b/src/main/java/io/aiven/klaw/clusterapi/services/MonitoringService.java
@@ -48,7 +48,6 @@ public class MonitoringService {
 
       TopicPartition topicPartition;
       Map<TopicPartition, OffsetSpec> topicPartitionOffsetSpecMap = new HashMap<>();
-      topicPartitionOffsetSpecMap = new HashMap<>();
 
       for (TopicPartitionInfo topicPartitionInfo : topicPartitions) {
         topicPartition = new TopicPartition(topicName, topicPartitionInfo.partition());

--- a/src/main/java/io/aiven/klaw/clusterapi/services/SchemaService.java
+++ b/src/main/java/io/aiven/klaw/clusterapi/services/SchemaService.java
@@ -10,8 +10,10 @@ import java.util.*;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.tuple.Pair;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.HttpClientErrorException;
@@ -21,6 +23,14 @@ import org.springframework.web.client.RestTemplate;
 @Service
 @Slf4j
 public class SchemaService {
+  private static final ParameterizedTypeReference<Map<String, String>>
+      GET_SCHEMA_COMPATIBILITY_TYPEREF = new ParameterizedTypeReference<>() {};
+  private static final ParameterizedTypeReference<Map<String, Object>> GET_SCHEMA_TYPEREF =
+      new ParameterizedTypeReference<>() {};
+
+  private static final ParameterizedTypeReference<List<Integer>> GET_SCHEMAVERSIONS_TYPEREF =
+      new ParameterizedTypeReference<>() {};
+
   public static final String SCHEMA_REGISTRY_CONTENT_TYPE =
       "application/vnd.schemaregistry.v1+json";
 
@@ -93,8 +103,11 @@ public class SchemaService {
 
           Map<String, String> params = new HashMap<>();
 
-          ResponseEntity<HashMap> responseNew =
-              reqDetails.getRight().getForEntity(reqDetails.getLeft(), HashMap.class, params);
+          ResponseEntity<Map<String, Object>> responseNew =
+              reqDetails
+                  .getRight()
+                  .exchange(reqDetails.getLeft(), HttpMethod.GET, null, GET_SCHEMA_TYPEREF, params);
+
           Map<String, Object> schemaResponse = responseNew.getBody();
           if (schemaResponse != null) {
             schemaResponse.put("compatibility", schemaCompatibility);
@@ -108,7 +121,7 @@ public class SchemaService {
       return allSchemaObjects;
     } catch (Exception e) {
       log.error("Error from getSchema : " + e.getMessage());
-      return new TreeMap<>();
+      return Collections.emptyMap();
     }
   }
 
@@ -126,13 +139,17 @@ public class SchemaService {
 
       Map<String, String> params = new HashMap<>();
 
-      ResponseEntity<ArrayList> responseList =
-          reqDetails.getRight().getForEntity(reqDetails.getLeft(), ArrayList.class, params);
+      ResponseEntity<List<Integer>> responseList =
+          reqDetails
+              .getRight()
+              .exchange(
+                  reqDetails.getLeft(), HttpMethod.GET, null, GET_SCHEMAVERSIONS_TYPEREF, params);
+
       log.info("Schema versions " + responseList);
       return responseList.getBody();
     } catch (Exception e) {
       log.error("Error in getting versions " + e.getMessage());
-      return new ArrayList<>();
+      return Collections.emptyList();
     }
   }
 
@@ -149,11 +166,18 @@ public class SchemaService {
           clusterApiUtils.getRequestDetails(suffixUrl, protocol, KafkaClustersType.SCHEMA_REGISTRY);
 
       Map<String, String> params = new HashMap<>();
+      ResponseEntity<Map<String, String>> responseList =
+          reqDetails
+              .getRight()
+              .exchange(
+                  reqDetails.getLeft(),
+                  HttpMethod.GET,
+                  null,
+                  GET_SCHEMA_COMPATIBILITY_TYPEREF,
+                  params);
 
-      ResponseEntity<HashMap> responseList =
-          reqDetails.getRight().getForEntity(reqDetails.getLeft(), HashMap.class, params);
       log.info("Schema compatibility " + responseList);
-      return (String) responseList.getBody().get("compatibilityLevel");
+      return responseList.getBody().get("compatibilityLevel");
     } catch (Exception e) {
       log.error("Error in getting schema compatibility " + e.getMessage());
       return "NOT SET";

--- a/src/test/java/io/aiven/klaw/clusterapi/services/KafkaConnectServiceTest.java
+++ b/src/test/java/io/aiven/klaw/clusterapi/services/KafkaConnectServiceTest.java
@@ -1,0 +1,79 @@
+package io.aiven.klaw.clusterapi.services;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.aiven.klaw.clusterapi.models.KafkaClustersType;
+import io.aiven.klaw.clusterapi.models.KafkaSupportedProtocol;
+import io.aiven.klaw.clusterapi.utils.ClusterApiUtils;
+import java.util.Collections;
+import org.apache.commons.lang3.tuple.Pair;
+import org.assertj.core.util.Lists;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.client.RestClientTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.client.MockRestServiceServer;
+import org.springframework.web.client.RestTemplate;
+
+@RestClientTest(KafkaConnectService.class)
+class KafkaConnectServiceTest {
+
+  @Autowired KafkaConnectService kafkaConnectService;
+
+  RestTemplate restTemplate;
+  @Autowired ObjectMapper objectMapper;
+  private MockRestServiceServer mockRestServiceServer;
+  @MockBean private ClusterApiUtils getAdminClient;
+
+  @BeforeEach
+  public void setUp() {
+    restTemplate = new RestTemplate();
+    kafkaConnectService = new KafkaConnectService(getAdminClient);
+    mockRestServiceServer = MockRestServiceServer.bindTo(restTemplate).build();
+  }
+
+  // TODO need to add proper return value
+  @Test
+  public void getConnectors_returnList() throws JsonProcessingException {
+    when(getAdminClient.getRequestDetails(any(), eq(KafkaSupportedProtocol.PLAINTEXT), any()))
+        .thenReturn(Pair.of("/env/connectors", restTemplate));
+    this.mockRestServiceServer
+        .expect(requestTo("/env/connectors"))
+        .andRespond(
+            withSuccess(
+                objectMapper.writeValueAsString(Lists.list("conn1", "conn2")),
+                MediaType.APPLICATION_JSON));
+
+    assertThat(kafkaConnectService.getConnectors("env", KafkaSupportedProtocol.PLAINTEXT))
+        .isNotEmpty();
+  }
+
+  // TODO need to add proper return value
+  @Test
+  public void getConnectorDetails_returnMap() throws JsonProcessingException {
+    when(getAdminClient.getRequestDetails(
+            any(), eq(KafkaSupportedProtocol.PLAINTEXT), eq(KafkaClustersType.KAFKA_CONNECT)))
+        .thenReturn(Pair.of("/env/connectors/conn1", restTemplate));
+    this.mockRestServiceServer
+        .expect(requestTo("/env/connectors/conn1"))
+        .andRespond(
+            withSuccess(
+                objectMapper.writeValueAsString(Collections.singletonMap("conn1", "conn2")),
+                MediaType.APPLICATION_JSON));
+
+    assertThat(
+            kafkaConnectService.getConnectorDetails(
+                "conn1", "env", KafkaSupportedProtocol.PLAINTEXT))
+        .isNotEmpty();
+  }
+}

--- a/src/test/java/io/aiven/klaw/clusterapi/services/SchemaServiceTest.java
+++ b/src/test/java/io/aiven/klaw/clusterapi/services/SchemaServiceTest.java
@@ -1,0 +1,97 @@
+package io.aiven.klaw.clusterapi.services;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.aiven.klaw.clusterapi.models.KafkaClustersType;
+import io.aiven.klaw.clusterapi.models.KafkaSupportedProtocol;
+import io.aiven.klaw.clusterapi.utils.ClusterApiUtils;
+import java.util.Collections;
+import org.apache.commons.lang3.tuple.Pair;
+import org.assertj.core.util.Lists;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.client.RestClientTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.client.MockRestServiceServer;
+import org.springframework.web.client.RestTemplate;
+
+@RestClientTest(SchemaService.class)
+class SchemaServiceTest {
+
+  @Autowired SchemaService schemaService;
+
+  RestTemplate restTemplate;
+  @Autowired ObjectMapper objectMapper;
+  private MockRestServiceServer mockRestServiceServer;
+  @MockBean private ClusterApiUtils getAdminClient;
+
+  @BeforeEach
+  public void setUp() {
+    restTemplate = new RestTemplate();
+    schemaService = new SchemaService(getAdminClient);
+    mockRestServiceServer = MockRestServiceServer.bindTo(restTemplate).build();
+  }
+
+  // TODO need to add proper return value
+  @Test
+  public void getSchema_returnMap() throws JsonProcessingException {
+    // getSchemaVersions
+    String getSchemaVersionsUrl = "env/subjects/topic-value/versions";
+    when(getAdminClient.getRequestDetails(
+            eq(getSchemaVersionsUrl),
+            eq(KafkaSupportedProtocol.PLAINTEXT),
+            eq(KafkaClustersType.SCHEMA_REGISTRY)))
+        .thenReturn(Pair.of(getSchemaVersionsUrl, restTemplate));
+    this.mockRestServiceServer
+        .expect(requestTo("/" + getSchemaVersionsUrl))
+        .andRespond(
+            withSuccess(
+                objectMapper.writeValueAsString(Lists.list(1)), MediaType.APPLICATION_JSON));
+
+    // getSchemaCompatibility
+    String getSchemaCompatibilityUrl = "env/config/topic-value";
+    when(getAdminClient.getRequestDetails(
+            eq(getSchemaCompatibilityUrl),
+            eq(KafkaSupportedProtocol.PLAINTEXT),
+            eq(KafkaClustersType.SCHEMA_REGISTRY)))
+        .thenReturn(Pair.of(getSchemaCompatibilityUrl, restTemplate));
+    this.mockRestServiceServer
+        .expect(requestTo("/" + getSchemaCompatibilityUrl))
+        .andRespond(
+            withSuccess(
+                objectMapper.writeValueAsString(
+                    Collections.singletonMap("compatibilityLevel", "great")),
+                MediaType.APPLICATION_JSON));
+
+    // getSchema
+    String getSchemaUrl = "env/subjects/topic-value/versions/1";
+    when(getAdminClient.getRequestDetails(
+            eq(getSchemaUrl),
+            eq(KafkaSupportedProtocol.PLAINTEXT),
+            eq(KafkaClustersType.SCHEMA_REGISTRY)))
+        .thenReturn(Pair.of(getSchemaUrl, restTemplate));
+
+    when(getAdminClient.getRequestDetails(
+            eq(getSchemaUrl), eq(KafkaSupportedProtocol.PLAINTEXT), any()))
+        .thenReturn(Pair.of(getSchemaUrl, restTemplate));
+    this.mockRestServiceServer
+        .expect(requestTo("/" + getSchemaUrl))
+        .andRespond(
+            withSuccess(
+                objectMapper.writeValueAsString(Collections.singletonMap("foo", "bar")),
+                MediaType.APPLICATION_JSON));
+
+    assertThat(schemaService.getSchema("env", KafkaSupportedProtocol.PLAINTEXT, "topic"))
+        .isNotEmpty();
+  }
+}


### PR DESCRIPTION
# What is the purpose of the change

This PR applies a set of "minor" refactorings:
- remove unused assignments
- avoid casting when using generic types with Spring RestTemplate
- use log.err(String, Throwable) instead of log.error(String, e.toString());
- Files.newInputStream instead of FileInputStream


I hope this provides some value.

